### PR TITLE
chore: ensure sharp optional deps on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "license:check": "license-check-and-add check",
     "lint": "eslint --ext .ts src",
     "prepare": "husky install",
+    "postinstall": "node scripts/install-sharp.js",
     "release": "release-it",
     "start": "node ./dist/server.js",
     "swagger:copy-assets": "shx cp -R ./node_modules/swagger-ui-dist ./swagger-docs",

--- a/scripts/install-sharp.js
+++ b/scripts/install-sharp.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/*
+ * This script ensures the optional sharp dependencies are installed when the
+ * current platform requires them (e.g. Render's Alpine-based environment).
+ */
+
+const { execSync } = require('node:child_process');
+
+function hasSharp() {
+  try {
+    require.resolve('sharp');
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+if (hasSharp()) {
+  console.log(
+    '[install-sharp] sharp already available, skipping optional install.'
+  );
+  process.exit(0);
+}
+
+console.log(
+  '[install-sharp] Attempting to install optional sharp dependencies for this platform...'
+);
+
+try {
+  execSync('npm install --include=optional --no-save sharp', {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      npm_config_update_notifier: 'false',
+    },
+  });
+  console.log('[install-sharp] Optional sharp dependencies installed.');
+} catch (error) {
+  console.warn(
+    '[install-sharp] Failed to install optional sharp dependencies automatically.'
+  );
+  console.warn(
+    '[install-sharp] Please install them manually if sharp is required.'
+  );
+}


### PR DESCRIPTION
## Summary
- add a postinstall script to attempt installing sharp optional dependencies automatically
- ensure Render and other environments get missing sharp binaries without manual intervention

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9ac813cc832794f95e467df6c650