### PR TITLE
fix: guard install-sharp postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "license:check": "license-check-and-add check",
     "lint": "eslint --ext .ts src",
     "prepare": "husky install",
+    "postinstall": "node -e \"try { require('./scripts/install-sharp'); } catch (err) { if (err?.code === 'MODULE_NOT_FOUND') { console.warn('[postinstall] install-sharp script not found; skipping optional dependencies install.'); } else { throw err; } }\"",
     "release": "release-it",
     "start": "node ./dist/server.js",
     "swagger:copy-assets": "shx cp -R ./node_modules/swagger-ui-dist ./swagger-docs",

--- a/scripts/install-sharp.js
+++ b/scripts/install-sharp.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/*
+ * This script ensures the optional sharp dependencies are installed when the
+ * current platform requires them (e.g. Render's Alpine-based environment).
+ */
+
+const { execSync } = require('node:child_process');
+
+function hasSharp() {
+  try {
+    require.resolve('sharp');
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+if (hasSharp()) {
+  console.log(
+    '[install-sharp] sharp already available, skipping optional install.'
+  );
+  process.exit(0);
+}
+
+console.log(
+  '[install-sharp] Attempting to install optional sharp dependencies for this platform...'
+);
+
+try {
+  execSync('npm install --include=optional --no-save sharp', {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      npm_config_update_notifier: 'false',
+    },
+  });
+  console.log('[install-sharp] Optional sharp dependencies installed.');
+} catch (error) {
+  console.warn(
+    '[install-sharp] Failed to install optional sharp dependencies automatically.'
+  );
+  console.warn(
+    '[install-sharp] Please install them manually if sharp is required.'
+  );
+}


### PR DESCRIPTION
## Summary
- guard the postinstall hook so installs on minimal Docker layers skip when the helper script is absent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9ac813cc832794f95e467df6c650